### PR TITLE
Fix timezone

### DIFF
--- a/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCell.m
+++ b/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCell.m
@@ -117,6 +117,7 @@
         todayFormatter.dateStyle = NSDateFormatterMediumStyle;
         todayFormatter.timeStyle = NSDateFormatterNoStyle;
         todayFormatter.doesRelativeDateFormatting = YES;
+        [todayFormatter setLocale:[[GLDateUtils calendar] locale]];
         [self setMonthLabelText:[todayFormatter stringFromDate:[NSDate date]]];
         self.dayLabel.textColor = [UIColor whiteColor];
         [self setTodayLabelText:[NSString stringWithFormat:@"%ld", (long)day]];
@@ -219,7 +220,9 @@
 static NSArray *months;
 - (NSString *)monthText:(NSInteger)month {
     if (!months) {
-        months = [[[[NSDateFormatter alloc] init] shortStandaloneMonthSymbols] valueForKeyPath:@"capitalizedString"];
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setLocale:[[GLDateUtils calendar] locale]];
+        months = [[dateFormatter shortStandaloneMonthSymbols] valueForKeyPath:@"capitalizedString"];
     }
     return [months objectAtIndex:(month - 1)];
 }

--- a/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.h
+++ b/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSInteger, RANGE_POSITION) {
 @property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, strong) UIImage *backgroundImage;
 @property (nonatomic) CGFloat borderWidth;
+@property (nonatomic) CGFloat circleDiameter;
 @property (nonatomic) BOOL inEdit;
 @property (nonatomic) BOOL isToday;
 @property (nonatomic) BOOL continuousRangeDisplay;

--- a/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.h
+++ b/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.h
@@ -25,7 +25,6 @@ typedef NS_ENUM(NSInteger, RANGE_POSITION) {
 @property (nonatomic, strong) UIColor *strokeColor;
 @property (nonatomic, strong) UIImage *backgroundImage;
 @property (nonatomic) CGFloat borderWidth;
-@property (nonatomic) CGFloat circleDiameter;
 @property (nonatomic) BOOL inEdit;
 @property (nonatomic) BOOL isToday;
 @property (nonatomic) BOOL continuousRangeDisplay;

--- a/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.m
+++ b/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.m
@@ -81,21 +81,18 @@
             CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
             CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
             
+            CGFloat circleDiameter;
+            
             if (heightWithPadding > widthWithPadding) {
-                self.circleDiameter = widthWithPadding;
+                circleDiameter = widthWithPadding;
             } else {
-                self.circleDiameter = heightWithPadding;
+                circleDiameter = heightWithPadding;
             }
             
-            self.beginPoint.center = CGPointMake(width / 2 - self.circleDiameter / 2, height / 2);
+            self.beginPoint.center = CGPointMake((width + paddingLeft - paddingRight) / 2 - circleDiameter / 2, height / 2);
             [self addSubview:self.beginPoint];
-            self.endPoint.center = CGPointMake(width / 2 + self.circleDiameter / 2, height / 2);
+            self.endPoint.center = CGPointMake((width + paddingLeft - paddingRight) / 2 + circleDiameter / 2, height / 2);
             [self addSubview:self.endPoint];
-            
-//            self.beginPoint.center = CGPointMake(self.borderWidth / 2 + self.paddingLeft, self.bounds.size.height / 2);
-//            [self addSubview:self.beginPoint];
-//            self.endPoint.center = CGPointMake(self.bounds.size.width - self.borderWidth / 2 - self.paddingRight, self.bounds.size.height / 2);
-//            [self addSubview:self.endPoint];
         } else {
             [_beginPoint removeFromSuperview];
             [_endPoint removeFromSuperview];
@@ -153,10 +150,12 @@
     CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
     CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
     
+    CGFloat circleDiameter;
+    
     if (heightWithPadding > widthWithPadding) {
-        self.circleDiameter = widthWithPadding;
+        circleDiameter = widthWithPadding;
     } else {
-        self.circleDiameter = heightWithPadding;
+        circleDiameter = heightWithPadding;
     }
     
     NSLog(@"left %f",self.paddingLeft);
@@ -166,8 +165,7 @@
     
     UIBezierPath *path = [UIBezierPath bezierPath];
     if (!self.inEdit && !self.continuousRangeDisplay) {
-//        CGRect rect = CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2);
-        CGRect rect = CGRectMake((width + paddingLeft - paddingRight) / 2 - self.circleDiameter / 2, (height - self.circleDiameter) / 2, self.circleDiameter, self.circleDiameter);
+        CGRect rect = CGRectMake((width + paddingLeft - paddingRight) / 2 - circleDiameter / 2, (height - circleDiameter) / 2, circleDiameter, circleDiameter);
         if (self.backgroundImage) {
             [self.backgroundImage drawInRect:rect];
             return;
@@ -203,13 +201,12 @@
         CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
         
         if (heightWithPadding > widthWithPadding) {
-            self.circleDiameter = widthWithPadding;
+            circleDiameter = widthWithPadding;
         } else {
-            self.circleDiameter = heightWithPadding;
+            circleDiameter = heightWithPadding;
         }
-        path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake((width + paddingLeft - paddingRight) / 2 - self.circleDiameter / 2, (height - self.circleDiameter) / 2, self.circleDiameter, self.circleDiameter)];
+        path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake((width + paddingLeft - paddingRight) / 2 - circleDiameter / 2, (height - circleDiameter) / 2, circleDiameter, circleDiameter)];
         
-//        path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2)];
         [path closePath];
     }
     if (_inEdit) {
@@ -239,24 +236,15 @@
     CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
     CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
     
+    CGFloat circleDiameter;
+    
     if (heightWithPadding > widthWithPadding) {
-        self.circleDiameter = widthWithPadding;
+        circleDiameter = widthWithPadding;
     } else {
-        self.circleDiameter = heightWithPadding;
+        circleDiameter = heightWithPadding;
     }
     
-    UIBezierPath *path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake((width + paddingLeft - paddingRight) / 2 - self.circleDiameter / 2, (height - self.circleDiameter) / 2, self.circleDiameter, self.circleDiameter)];
-    
-//    CGFloat paddingLeft = self.paddingLeft;
-//    CGFloat paddingRight = self.paddingRight;
-//    CGFloat paddingTop = self.paddingTop;
-//    
-//    CGFloat borderWidth = self.borderWidth;
-//    
-//    CGFloat height = rect.size.height;
-//    CGFloat width = rect.size.width;
-//            
-//    UIBezierPath *path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2)];
+    UIBezierPath *path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake((width + paddingLeft - paddingRight) / 2 - circleDiameter / 2, (height - circleDiameter) / 2, circleDiameter, circleDiameter)];
     
     [path closePath];
     [self.fillColor setFill];
@@ -288,4 +276,5 @@
     pointView.center = center;
     pointView.layer.cornerRadius = size / 2;
 }
+
 @end

--- a/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.m
+++ b/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.m
@@ -158,11 +158,6 @@
         circleDiameter = heightWithPadding;
     }
     
-    NSLog(@"left %f",self.paddingLeft);
-    NSLog(@"right %f",self.paddingRight);
-    NSLog(@"top %f",self.paddingTop);
-    NSLog(@"borderWidth %f",self.borderWidth);
-    
     UIBezierPath *path = [UIBezierPath bezierPath];
     if (!self.inEdit && !self.continuousRangeDisplay) {
         CGRect rect = CGRectMake((width + paddingLeft - paddingRight) / 2 - circleDiameter / 2, (height - circleDiameter) / 2, circleDiameter, circleDiameter);

--- a/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.m
+++ b/GLCalendarView/Sources/GLCalendarDayCell/GLCalendarDayCellBackgroundCover.m
@@ -69,10 +69,33 @@
             [self addSubview:self.endPoint];
             [_beginPoint removeFromSuperview];
         } else if (self.rangePosition == RANGE_POSITION_SINGLE) {
-            self.beginPoint.center = CGPointMake(self.borderWidth / 2 + self.paddingLeft, self.bounds.size.height / 2);
+            CGFloat paddingLeft = self.paddingLeft;
+            CGFloat paddingRight = self.paddingRight;
+            CGFloat paddingTop = self.paddingTop;
+            
+            CGFloat borderWidth = self.borderWidth;
+            
+            CGFloat height = self.bounds.size.height;
+            CGFloat width = self.bounds.size.width;
+            
+            CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
+            CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
+            
+            if (heightWithPadding > widthWithPadding) {
+                self.circleDiameter = widthWithPadding;
+            } else {
+                self.circleDiameter = heightWithPadding;
+            }
+            
+            self.beginPoint.center = CGPointMake(width / 2 - self.circleDiameter / 2, height / 2);
             [self addSubview:self.beginPoint];
-            self.endPoint.center = CGPointMake(self.bounds.size.width - self.borderWidth / 2 - self.paddingRight, self.bounds.size.height / 2);
+            self.endPoint.center = CGPointMake(width / 2 + self.circleDiameter / 2, height / 2);
             [self addSubview:self.endPoint];
+            
+//            self.beginPoint.center = CGPointMake(self.borderWidth / 2 + self.paddingLeft, self.bounds.size.height / 2);
+//            [self addSubview:self.beginPoint];
+//            self.endPoint.center = CGPointMake(self.bounds.size.width - self.borderWidth / 2 - self.paddingRight, self.bounds.size.height / 2);
+//            [self addSubview:self.endPoint];
         } else {
             [_beginPoint removeFromSuperview];
             [_endPoint removeFromSuperview];
@@ -127,9 +150,24 @@
     
     CGFloat midY = CGRectGetMidY(rect);
     
+    CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
+    CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
+    
+    if (heightWithPadding > widthWithPadding) {
+        self.circleDiameter = widthWithPadding;
+    } else {
+        self.circleDiameter = heightWithPadding;
+    }
+    
+    NSLog(@"left %f",self.paddingLeft);
+    NSLog(@"right %f",self.paddingRight);
+    NSLog(@"top %f",self.paddingTop);
+    NSLog(@"borderWidth %f",self.borderWidth);
+    
     UIBezierPath *path = [UIBezierPath bezierPath];
     if (!self.inEdit && !self.continuousRangeDisplay) {
-        CGRect rect = CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2);
+//        CGRect rect = CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2);
+        CGRect rect = CGRectMake((width + paddingLeft - paddingRight) / 2 - self.circleDiameter / 2, (height - self.circleDiameter) / 2, self.circleDiameter, self.circleDiameter);
         if (self.backgroundImage) {
             [self.backgroundImage drawInRect:rect];
             return;
@@ -160,7 +198,18 @@
         [path addLineToPoint:CGPointMake(0, height - borderWidth - paddingTop)];
         [path closePath];
     } else if (self.rangePosition == RANGE_POSITION_SINGLE) {
-        path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2)];
+        
+        CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
+        CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
+        
+        if (heightWithPadding > widthWithPadding) {
+            self.circleDiameter = widthWithPadding;
+        } else {
+            self.circleDiameter = heightWithPadding;
+        }
+        path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake((width + paddingLeft - paddingRight) / 2 - self.circleDiameter / 2, (height - self.circleDiameter) / 2, self.circleDiameter, self.circleDiameter)];
+        
+//        path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2)];
         [path closePath];
     }
     if (_inEdit) {
@@ -177,6 +226,7 @@
     if (!self.isToday) {
         return;
     }
+    
     CGFloat paddingLeft = self.paddingLeft;
     CGFloat paddingRight = self.paddingRight;
     CGFloat paddingTop = self.paddingTop;
@@ -185,8 +235,29 @@
     
     CGFloat height = rect.size.height;
     CGFloat width = rect.size.width;
-            
-    UIBezierPath *path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2)];
+    
+    CGFloat heightWithPadding = height - borderWidth * 2 - paddingTop * 2;
+    CGFloat widthWithPadding = width - borderWidth * 2 - paddingLeft - paddingRight;
+    
+    if (heightWithPadding > widthWithPadding) {
+        self.circleDiameter = widthWithPadding;
+    } else {
+        self.circleDiameter = heightWithPadding;
+    }
+    
+    UIBezierPath *path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake((width + paddingLeft - paddingRight) / 2 - self.circleDiameter / 2, (height - self.circleDiameter) / 2, self.circleDiameter, self.circleDiameter)];
+    
+//    CGFloat paddingLeft = self.paddingLeft;
+//    CGFloat paddingRight = self.paddingRight;
+//    CGFloat paddingTop = self.paddingTop;
+//    
+//    CGFloat borderWidth = self.borderWidth;
+//    
+//    CGFloat height = rect.size.height;
+//    CGFloat width = rect.size.width;
+//            
+//    UIBezierPath *path = [UIBezierPath bezierPathWithOvalInRect: CGRectMake(borderWidth + paddingLeft, borderWidth + paddingTop, width - borderWidth * 2 - paddingLeft - paddingRight,  height - borderWidth * 2 - paddingTop * 2)];
+    
     [path closePath];
     [self.fillColor setFill];
     [path fill];

--- a/GLCalendarView/Sources/GLCalendarMonthCoverView.m
+++ b/GLCalendarView/Sources/GLCalendarMonthCoverView.m
@@ -27,6 +27,7 @@
     [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
     
     NSDateFormatter *monthFormatter = [[NSDateFormatter alloc] init];
+    [monthFormatter setLocale:[[GLDateUtils calendar] locale]];
     monthFormatter.dateFormat = @"YYYY\nMMMM";
 
     NSDateComponents *today = [calendar components:NSCalendarUnitYear fromDate:[NSDate date]];

--- a/GLCalendarView/Sources/GLCalendarView.m
+++ b/GLCalendarView/Sources/GLCalendarView.m
@@ -26,6 +26,9 @@ static NSString * const CELL_REUSE_IDENTIFIER = @"DayCell";
 @property (nonatomic) BOOL draggingBeginDate;
 @property (nonatomic) BOOL draggingEndDate;
 
+@property (nonatomic, strong) NSDateComponents *firstDateComponents;
+@property (nonatomic, strong) NSDateComponents *lastDateComponents;
+
 @property (weak, nonatomic) IBOutlet UICollectionView *collectionView;
 @property (weak, nonatomic) IBOutlet UIView *weekDayTitle;
 @property (weak, nonatomic) IBOutlet GLCalendarMonthCoverView *monthCoverView;
@@ -34,9 +37,6 @@ static NSString * const CELL_REUSE_IDENTIFIER = @"DayCell";
 @end
 
 @implementation GLCalendarView
-
-@synthesize firstDate = _firstDate;
-@synthesize lastDate = _lastDate;
 
 - (id)initWithFrame:(CGRect)frame
 {
@@ -187,28 +187,35 @@ static NSString * const CELL_REUSE_IDENTIFIER = @"DayCell";
 
 - (void)setFirstDate:(NSDate *)firstDate
 {
-    _firstDate = [GLDateUtils weekFirstDate:[GLDateUtils cutDate:firstDate]];
+    NSDate *date = [GLDateUtils weekFirstDate:[GLDateUtils cutDate:firstDate]];
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    self.firstDateComponents = [calendar components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit fromDate:date];
 }
 
 - (NSDate *)firstDate
 {
-    if (!_firstDate) {
+    if (!self.firstDateComponents) {
         self.firstDate = [GLDateUtils dateByAddingDays:-365 toDate:[NSDate date]];
     }
-    return _firstDate;
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    
+    return [calendar dateFromComponents:self.firstDateComponents];
 }
 
 - (void)setLastDate:(NSDate *)lastDate
 {
-    _lastDate = [GLDateUtils weekLastDate:[GLDateUtils cutDate:lastDate]];
+    NSDate *date = [GLDateUtils weekLastDate:[GLDateUtils cutDate:lastDate]];
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    self.lastDateComponents = [calendar components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit fromDate:lastDate];
 }
 
 - (NSDate *)lastDate
 {
-    if (!_lastDate) {
+    if (!self.lastDateComponents) {
         self.lastDate = [GLDateUtils dateByAddingDays:30 toDate:[NSDate date]];
     }
-    return _lastDate;
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    return [calendar dateFromComponents:self.lastDateComponents];
 }
 
 # pragma mark - UICollectionView data source

--- a/GLCalendarView/Sources/GLDateUtils.m
+++ b/GLCalendarView/Sources/GLDateUtils.m
@@ -133,7 +133,9 @@
 static NSArray *months;
 + (NSString *)monthText:(NSInteger)month {
     if (!months) {
-        months = [[[NSDateFormatter alloc] init] shortStandaloneMonthSymbols];
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setLocale:[[GLDateUtils calendar] locale]];
+        months = [dateFormatter shortStandaloneMonthSymbols];
     }
     return [months objectAtIndex:(month - 1)];
 }


### PR DESCRIPTION
Fix a timezone issue.
In normal conditions, the calendar selection are NSDate corresponding to the 00:00 of the selected date. But if the timezone is changed after the GLCalendarView is instantiated, this NSDate may corresponds to other times (e.g. 23:00 if the timezone is one hour earlier)